### PR TITLE
Transfer repo to TuringLang

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -4,7 +4,7 @@ Copyright (c) 2021 Brian J Smith, the Turing team and contributors:
 
 https://github.com/brian-j-smith/Mamba.jl/contributors
 https://github.com/TuringLang/MCMCChains.jl/contributors
-https://github.com/devmotion/MCMCDiagnosticTools.jl/contributors
+https://github.com/TuringLang/MCMCDiagnosticTools.jl/contributors
 https://turing.ml/dev/team/
 
 Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # MCMCDiagnosticTools.jl
 
-[![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://devmotion.github.io/MCMCDiagnosticTools.jl/stable)
-[![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://devmotion.github.io/MCMCDiagnosticTools.jl/dev)
-[![Build Status](https://github.com/devmotion/MCMCDiagnosticTools.jl/workflows/CI/badge.svg?branch=main)](https://github.com/devmotion/MCMCDiagnosticTools.jl/actions?query=workflow%3ACI+branch%3Amain)
-[![Coverage](https://codecov.io/gh/devmotion/MCMCDiagnosticTools.jl/branch/main/graph/badge.svg)](https://codecov.io/gh/devmotion/MCMCDiagnosticTools.jl)
-[![Coverage](https://coveralls.io/repos/github/devmotion/MCMCDiagnosticTools.jl/badge.svg?branch=main)](https://coveralls.io/github/devmotion/MCMCDiagnosticTools.jl?branch=main)
+[![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://turinglang.github.io/MCMCDiagnosticTools.jl/stable)
+[![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://turinglang.github.io/MCMCDiagnosticTools.jl/dev)
+[![Build Status](https://github.com/TuringLang/MCMCDiagnosticTools.jl/workflows/CI/badge.svg?branch=main)](https://github.com/TuringLang/MCMCDiagnosticTools.jl/actions?query=workflow%3ACI+branch%3Amain)
+[![Coverage](https://codecov.io/gh/TuringLang/MCMCDiagnosticTools.jl/branch/main/graph/badge.svg)](https://codecov.io/gh/TuringLang/MCMCDiagnosticTools.jl)
+[![Coverage](https://coveralls.io/repos/github/TuringLang/MCMCDiagnosticTools.jl/badge.svg?branch=main)](https://coveralls.io/github/TuringLang/MCMCDiagnosticTools.jl?branch=main)
 [![Code Style: Blue](https://img.shields.io/badge/code%20style-blue-4495d1.svg)](https://github.com/invenia/BlueStyle)
 [![ColPrac: Contributor's Guide on Collaborative Practices for Community Packages](https://img.shields.io/badge/ColPrac-Contributor's%20Guide-blueviolet)](https://github.com/SciML/ColPrac)
 

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -14,11 +14,11 @@ DocMeta.setdocmeta!(
 makedocs(;
     modules=[MCMCDiagnosticTools],
     authors="David Widmann",
-    repo="https://github.com/devmotion/MCMCDiagnosticTools.jl/blob/{commit}{path}#{line}",
+    repo="https://github.com/TuringLang/MCMCDiagnosticTools.jl/blob/{commit}{path}#{line}",
     sitename="MCMCDiagnosticTools.jl",
     format=Documenter.HTML(;
         prettyurls=get(ENV, "CI", "false") == "true",
-        canonical="https://devmotion.github.io/MCMCDiagnosticTools.jl",
+        canonical="https://turinglang.github.io/MCMCDiagnosticTools.jl",
         assets=String[],
     ),
     pages=["Home" => "index.md"],
@@ -27,5 +27,5 @@ makedocs(;
 )
 
 deploydocs(;
-    repo="github.com/devmotion/MCMCDiagnosticTools.jl", push_preview=true, devbranch="main"
+    repo="github.com/TuringLang/MCMCDiagnosticTools.jl", push_preview=true, devbranch="main"
 )


### PR DESCRIPTION
As I wrote in https://github.com/TuringLang/MCMCDiagnosticTools.jl/issues/25#issuecomment-975495311, I think the package shouldn't live in my Github account. Due to its close relation and integration with MCMCChains, I think currently it fits best in TuringLang. However, the plan is to transfer it to arviz-devs in the future if ArviZ starts to use and contribute to MCMCDiagnosticTools, and MCMCChains (and ParetoSmooth) are not the only dependents anymore :slightly_smiling_face: 

This PR updates the links and deployment of the docs.

@yebai I don't have admin rights anymore, so I can't adjust the link in the description on https://github.com/TuringLang/MCMCDiagnosticTools.jl. Can you fix it?

I'll make a PR to the registry and update the links there when the PR is merged.