### PR TITLE
Update CompatHelper.yml

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -20,7 +20,7 @@ jobs:
       - name: "Run CompatHelper"
         run: |
           import CompatHelper
-          CompatHelper.main(; subdirs=["", "test", "test/rstar", "docs"])
+          CompatHelper.main(; subdirs=["", "test", "docs"])
         shell: julia --color=yes {0}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Fix CompatHelper. Currently it errors since test/rstar/Project.toml does not exist anymore.

Triggered it manually on this branch to make sure it is fixed: https://github.com/TuringLang/MCMCDiagnosticTools.jl/actions/runs/3693023553