### PR TITLE
Run CI nightly

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - main
   pull_request:
+  schedule:
+    - cron: "0 0 * * *"
 
 jobs:
   test:


### PR DESCRIPTION
CI seems to be failing on main, but this is not reflected in the CI status, since it does not run on a schedule. This PR adds a nightly run of CI.