### PR TITLE
Update TagBot workflow

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -5,7 +5,22 @@ on:
     types:
       - created
   workflow_dispatch:
-
+    inputs:
+      lookback:
+        default: 3
+permissions:
+  actions: read
+  checks: read
+  contents: write
+  deployments: read
+  issues: read
+  discussions: read
+  packages: read
+  pages: read
+  pull-requests: read
+  repository-projects: read
+  security-events: read
+  statuses: read
 jobs:
   TagBot:
     if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'


### PR DESCRIPTION
This PR updates the TagBot workflow to the latest recommended file (see https://github.com/JuliaRegistries/TagBot#setup).

The main reason for this is the added ability to specify the lookback when manually triggering TagBot (TagBot has had issues recently, so some of our more recent registered versions have not had tagged releases, and with this change we can trigger TagBot to generate those older releases)