### PR TITLE
Remove DEV suffix from version number

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MCMCDiagnosticTools"
 uuid = "be115224-59cd-429b-ad48-344e309966f0"
 authors = ["David Widmann"]
-version = "0.3.0-DEV"
+version = "0.3.0"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"


### PR DESCRIPTION
With recent PRs, all planned breaking changes have been made for v0.3.0, so this PR updates the version number accordingly. It should be merged after tests pass in #73 and #74, which have already been approved.