### PR TITLE
Update docs to mention ArviZ partnership

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "MCMCDiagnosticTools"
 uuid = "be115224-59cd-429b-ad48-344e309966f0"
-authors = ["David Widmann"]
+authors = ["David Widmann", "Seth Axen"]
 version = "0.3.6"
 
 [deps]

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 [![Aqua QA](https://raw.githubusercontent.com/JuliaTesting/Aqua.jl/master/badge.svg)](https://github.com/JuliaTesting/Aqua.jl)
 [![Code Style: Blue](https://img.shields.io/badge/code%20style-blue-4495d1.svg)](https://github.com/invenia/BlueStyle)
 [![ColPrac: Contributor's Guide on Collaborative Practices for Community Packages](https://img.shields.io/badge/ColPrac-Contributor's%20Guide-blueviolet)](https://github.com/SciML/ColPrac)
+[![Powered by NumFOCUS](https://img.shields.io/badge/powered%20by-NumFOCUS-orange.svg?style=flat&colorA=E1523D&colorB=007D8A)](https://numfocus.org)
 
 Functionality for diagnosing samples generated using Markov Chain Monte Carlo.
 

--- a/README.md
+++ b/README.md
@@ -9,5 +9,6 @@
 [![Code Style: Blue](https://img.shields.io/badge/code%20style-blue-4495d1.svg)](https://github.com/invenia/BlueStyle)
 [![ColPrac: Contributor's Guide on Collaborative Practices for Community Packages](https://img.shields.io/badge/ColPrac-Contributor's%20Guide-blueviolet)](https://github.com/SciML/ColPrac)
 
-This package was originally part of [MCMCChains.jl](https://github.com/TuringLang/MCMCChains.jl).
+Functionality for diagnosing samples generated using Markov Chain Monte Carlo.
+
 This package is a joint collaboration between the [Turing](https://turinglang.org/) and [ArviZ](https://www.arviz.org/) projects.

--- a/README.md
+++ b/README.md
@@ -10,3 +10,4 @@
 [![ColPrac: Contributor's Guide on Collaborative Practices for Community Packages](https://img.shields.io/badge/ColPrac-Contributor's%20Guide-blueviolet)](https://github.com/SciML/ColPrac)
 
 This package was originally part of [MCMCChains.jl](https://github.com/TuringLang/MCMCChains.jl).
+This package is a joint collaboration between the [Turing](https://turinglang.org/) and [ArviZ](https://www.arviz.org/) projects.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -4,6 +4,8 @@ CurrentModule = MCMCDiagnosticTools
 
 # MCMCDiagnosticTools
 
+MCMCDiagnosticTools provides functionality for diagnosing samples generated using Markov Chain Monte Carlo.
+
 ## Effective sample size and $\widehat{R}$
 
 ```@docs

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -6,6 +6,11 @@ CurrentModule = MCMCDiagnosticTools
 
 MCMCDiagnosticTools provides functionality for diagnosing samples generated using Markov Chain Monte Carlo.
 
+## Background
+
+Some methods were originally part of [Mamba.jl](https://github.com/brian-j-smith/Mamba.jl) and then [MCMCChains.jl](https://github.com/TuringLang/MCMCChains.jl).
+This package is a joint collaboration between the [Turing](https://turinglang.org/) and [ArviZ](https://www.arviz.org/) projects.
+
 ## Effective sample size and $\widehat{R}$
 
 ```@docs

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -47,6 +47,9 @@ bfmi
 
 ## Other diagnostics
 
+!!! note
+    These diagnostics are older and less widely used.
+
 ```@docs
 discretediag
 gelmandiag


### PR DESCRIPTION
Following https://github.com/TuringLang/MCMCDiagnosticTools.jl/issues/25#issuecomment-1446216585, this PR updates the readme and docs to mention that this is a joint project between Turing and ArviZ.

It also
- adds a NumFOCUS badge (on all the ArviZ component packages, since ArviZ is sponsored)
- adds me as coauthor
- adds an admonition for the less common (and not-so-well-maintained) diagnostics.