### PR TITLE
Update ess_hat to not error for short chains

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "MCMCDiagnosticTools"
 uuid = "be115224-59cd-429b-ad48-344e309966f0"
 authors = ["David Widmann", "Seth Axen"]
-version = "0.3.8"
+version = "0.3.9"
 
 [deps]
 AbstractFFTs = "621f4979-c628-5d54-868e-fcf4e3e8185c"

--- a/src/ess_rhat.jl
+++ b/src/ess_rhat.jl
@@ -462,7 +462,7 @@ function _ess_rhat(
     # leave the last even autocorrelation as a bias term that reduces variance for
     # case of antithetical chains, see below
     if !(niter > 4)
-        throw(ArgumentError("number of draws after splitting must >4 but is $niter."))
+        @warn "number of draws after splitting must be >4 but is $niter. ESS cannot be computed."
     end
     maxlag > 0 || throw(DomainError(maxlag, "maxlag must be >0."))
     maxlag = min(maxlag, niter - 4)
@@ -517,6 +517,12 @@ function _ess_rhat(
 
         # estimate rhat
         rhat[i] = sqrt(var₊ / W)
+
+        # only estimate ESS if we have sufficient draws
+        if !(niter > 4)
+            ess[i] = T(NaN)
+            continue
+        end
 
         # center the data around 0
         samples .-= chain_mean

--- a/test/ess_rhat.jl
+++ b/test/ess_rhat.jl
@@ -70,9 +70,21 @@ mymean(x) = mean(x)
             @testset for f in (ess, ess_rhat)
                 @testset for kind in (:rank, :bulk, :tail, :basic)
                     f === ess && kind === :rank && continue
-                    @test_throws ArgumentError f(x; split_chains=1, kind=kind)
+                    if f === ess
+                        @test all(isnan, f(x; split_chains=1, kind=kind))
+                    else
+                        @test all(isnan, f(x; split_chains=1, kind=kind).ess)
+                        @test f(x; split_chains=1, kind=kind).rhat ==
+                            rhat(x; split_chains=1, kind=kind)
+                    end
                     f(x2; split_chains=1, kind=kind)
-                    @test_throws ArgumentError f(x2; split_chains=2, kind=kind)
+                    if f === ess
+                        @test all(isnan, f(x2; split_chains=2, kind=kind))
+                    else
+                        @test all(isnan, f(x2; split_chains=2, kind=kind).ess)
+                        @test f(x2; split_chains=2, kind=kind).rhat ==
+                            rhat(x2; split_chains=2, kind=kind)
+                    end
                     f(x3; maxlag=1, kind=kind)
                     @test_throws DomainError f(x3; maxlag=0, kind=kind)
                 end


### PR DESCRIPTION
Fixes #117. As a side benefit, `ess_rhat` for the `rhat` now returns the same thing as `rhat` even for few draws.