### PR TITLE
ci: Skip Aqua persistent tasks in downgrade

### DIFF
--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -39,6 +39,9 @@ jobs:
         with:
           project: "test"
       - uses: julia-actions/julia-runtest@v1
+        # Aqua's persistent-task check ignores the downgraded manifest.
+        env:
+          AQUA_PERSISTENT_TASKS: 'false'
         with:
           coverage: true
           allow_reresolve: false

--- a/test/aqua.jl
+++ b/test/aqua.jl
@@ -5,6 +5,7 @@ using Test
 @testset "Aqua" begin
     # Test ambiguities separately without Base and Core
     # Ref: https://github.com/JuliaTesting/Aqua.jl/issues/77
-    Aqua.test_all(MCMCDiagnosticTools; ambiguities=false)
+    persistent_tasks = parse(Bool, get(ENV, "AQUA_PERSISTENT_TASKS", "true"))
+    Aqua.test_all(MCMCDiagnosticTools; ambiguities=false, persistent_tasks)
     Aqua.test_ambiguities(MCMCDiagnosticTools)
 end


### PR DESCRIPTION
Disables Aqua’s persistent-task check only in the Downgrade workflow. It resolves a separate latest-compatible environment, not the downgraded manifest, causing unrelated precompile failures.

Regular CI continues to run the check.